### PR TITLE
fix: resolve history not updating and improve UX in history window

### DIFF
--- a/Calculator.csproj
+++ b/Calculator.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Core\Services\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="UI\CalculatorView.xaml.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>

--- a/Core/Models/CalculationHistory.cs
+++ b/Core/Models/CalculationHistory.cs
@@ -40,10 +40,5 @@ namespace Calculator.Core.Models
         public string Expression { get; set; }
         public CalcValue Result { get; set; }
         public DateTime Timestamp { get; set; }
-
-        public override string ToString()
-        {
-            return $"{Expression} = {Result}";
-        }
     }
 }

--- a/Core/Services/HistoryService.cs
+++ b/Core/Services/HistoryService.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Calculator.Core.Models;
+
+namespace Calculator.Core.Services
+{
+    public class HistoryService
+    {
+        public ObservableCollection<HistoryItem> Items { get; }
+
+        public HistoryService()
+        {
+            Items = new ObservableCollection<HistoryItem>();
+        }
+
+        public void Add(string expression, CalcValue result)
+        {
+            Items.Insert(0, new HistoryItem
+            {
+                Expression = expression,
+                Result = result,
+                Timestamp = DateTime.Now
+            });
+        }
+
+        public void Remove(HistoryItem item)
+        {
+            if (Items.Contains(item))
+                Items.Remove(item);
+        }
+
+        public void Clear()
+        {
+            Items.Clear();
+        }
+    }
+}

--- a/UI/ViewModels/HistoryViewModel.cs
+++ b/UI/ViewModels/HistoryViewModel.cs
@@ -1,10 +1,10 @@
 ﻿using Calculator.Core.Models;
+using Calculator.Core.Services;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
-using System.Linq;
 
 namespace Calculator.UI.ViewModels
 {
@@ -14,7 +14,8 @@ namespace Calculator.UI.ViewModels
         private readonly Window window;
         private HistoryItem selectedHistoryItem;
 
-        public ObservableCollection<HistoryItem> HistoryItems { get; }
+        // CalculatorViewModel의 HistoryItems를 직접 참조
+        public ObservableCollection<HistoryItem> HistoryItems => calculatorViewModel.HistoryItems;
 
         public HistoryItem SelectedHistoryItem
         {
@@ -27,100 +28,35 @@ namespace Calculator.UI.ViewModels
         }
 
         public ICommand UseSelectedCommand { get; }
+        public ICommand DeleteSelectedCommand { get; }
         public ICommand ClearHistoryCommand { get; }
 
         public HistoryViewModel(CalculatorViewModel calculatorViewModel, Window window)
         {
             this.calculatorViewModel = calculatorViewModel;
             this.window = window;
-            HistoryItems = new ObservableCollection<HistoryItem>();
-
-            RefreshHistory(); // 초기 로드
 
             UseSelectedCommand = new RelayCommand(ExecuteUseSelected, CanUseSelected);
+            DeleteSelectedCommand = new RelayCommand(ExecuteDeleteSelected, CanUseSelected);
             ClearHistoryCommand = new RelayCommand(ExecuteClearHistory);
         }
 
-        // 외부에서 호출할 수 있는 히스토리 새로고침 메서드
-        public void RefreshHistory()
-        {
-            HistoryItems.Clear();
-
-            // CalculatorViewModel에 Calculator 속성이 있는지 확인하고, 없으면 대안 방법 사용
-            var historyItems = GetHistoryItems();
-
-            foreach (var item in historyItems)
-            {
-                HistoryItems.Add(item);
-            }
-        }
-
-        private System.Collections.Generic.IEnumerable<HistoryItem> GetHistoryItems()
-        {
-            // Calculator 속성에 접근할 수 있는지 확인
-            var calculatorProperty = calculatorViewModel.GetType().GetProperty("Calculator");
-            if (calculatorProperty != null)
-            {
-                var calculator = calculatorProperty.GetValue(calculatorViewModel);
-                var historyProperty = calculator?.GetType().GetProperty("History");
-                if (historyProperty != null)
-                {
-                    var history = historyProperty.GetValue(calculator);
-                    var itemsProperty = history?.GetType().GetProperty("Items");
-                    if (itemsProperty != null)
-                    {
-                        var items = itemsProperty.GetValue(history) as System.Collections.Generic.IEnumerable<HistoryItem>;
-                        return items?.Reverse().Take(50) ?? new System.Collections.Generic.List<HistoryItem>();
-                    }
-                }
-            }
-
-            // 대안: CalculatorViewModel에서 히스토리를 직접 가져오는 메서드가 있는지 확인
-            var getHistoryMethod = calculatorViewModel.GetType().GetMethod("GetHistory");
-            if (getHistoryMethod != null)
-            {
-                var result = getHistoryMethod.Invoke(calculatorViewModel, null);
-                if (result is System.Collections.Generic.IEnumerable<HistoryItem> historyItems)
-                {
-                    return historyItems.Reverse().Take(50);
-                }
-            }
-
-            return new System.Collections.Generic.List<HistoryItem>();
-        }
-
-        private bool CanUseSelected(object parameter)
-        {
-            return SelectedHistoryItem != null;
-        }
+        private bool CanUseSelected(object parameter) => SelectedHistoryItem != null;
 
         private void ExecuteUseSelected(object parameter)
         {
             if (SelectedHistoryItem != null)
             {
-                // 선택된 계산식을 메인 계산기에 입력
                 calculatorViewModel.CurrentInput = SelectedHistoryItem.Expression;
                 calculatorViewModel.Display = SelectedHistoryItem.Expression;
+            }
+        }
 
-                // 결과 표시 상태 해제 (새로운 입력 시작)
-                // SetResultDisplayed 메서드가 있는지 확인하고 호출
-                var setResultDisplayedMethod = calculatorViewModel.GetType().GetMethod("SetResultDisplayed");
-                if (setResultDisplayedMethod != null)
-                {
-                    setResultDisplayedMethod.Invoke(calculatorViewModel, new object[] { false });
-                }
-                else
-                {
-                    // 대안: IsResultDisplayed 속성이 있다면 직접 설정
-                    var isResultDisplayedProperty = calculatorViewModel.GetType().GetProperty("IsResultDisplayed");
-                    if (isResultDisplayedProperty != null && isResultDisplayedProperty.CanWrite)
-                    {
-                        isResultDisplayedProperty.SetValue(calculatorViewModel, false);
-                    }
-                }
-
-                // 창 닫기
-                window?.Close();
+        private void ExecuteDeleteSelected(object parameter)
+        {
+            if (SelectedHistoryItem != null)
+            {
+                calculatorViewModel.History.Remove(SelectedHistoryItem);
             }
         }
 
@@ -134,23 +70,7 @@ namespace Calculator.UI.ViewModels
 
             if (result == MessageBoxResult.Yes)
             {
-                // ClearHistoryCommand가 있는지 확인하고 실행
-                var clearHistoryCommand = calculatorViewModel.ClearHistoryCommand;
-                if (clearHistoryCommand != null && clearHistoryCommand.CanExecute(null))
-                {
-                    clearHistoryCommand.Execute(null);
-                }
-                else
-                {
-                    // 대안: ClearHistory 메서드 직접 호출
-                    var clearHistoryMethod = calculatorViewModel.GetType().GetMethod("ClearHistory");
-                    if (clearHistoryMethod != null)
-                    {
-                        clearHistoryMethod.Invoke(calculatorViewModel, null);
-                    }
-                }
-
-                HistoryItems.Clear();
+                calculatorViewModel.History.Clear();
             }
         }
 

--- a/UI/Views/HistoryWindow.xaml
+++ b/UI/Views/HistoryWindow.xaml
@@ -57,16 +57,16 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- 헤더 -->
+        <!-- Header -->
         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="계산 히스토리" FontSize="16" FontWeight="SemiBold" 
+            <TextBlock Text="Calculation History" FontSize="16" FontWeight="SemiBold" 
                        VerticalAlignment="Center"/>
-            <TextBlock Text="{Binding HistoryItems.Count, StringFormat=({0}개)}" 
+            <TextBlock Text="{Binding HistoryItems.Count, StringFormat=({0} items)}" 
                        FontSize="12" Foreground="Gray" 
                        VerticalAlignment="Center" Margin="10,0,0,0"/>
         </StackPanel>
 
-        <!-- 히스토리 리스트 -->
+        <!-- History List -->
         <ListView Grid.Row="1" 
                   ItemsSource="{Binding HistoryItems}"
                   SelectedItem="{Binding SelectedHistoryItem}"
@@ -74,7 +74,7 @@
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled">
             <ListView.View>
                 <GridView>
-                    <GridViewColumn Header="계산식" Width="150">
+                    <GridViewColumn Header="Expression" Width="150">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Expression}" 
@@ -83,7 +83,7 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn Header="결과" Width="100">
+                    <GridViewColumn Header="Result" Width="100">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Result}" 
@@ -93,7 +93,7 @@
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn Header="시간" Width="80">
+                    <GridViewColumn Header="Time" Width="80">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Timestamp, StringFormat=HH:mm:ss}" 
@@ -106,16 +106,16 @@
             </ListView.View>
         </ListView>
 
-        <!-- 버튼 영역 -->
+        <!-- Button Area -->
         <StackPanel Grid.Row="2" Orientation="Horizontal" 
                     HorizontalAlignment="Right" Margin="0,10,0,0">
-            <Button Content="선택된 식 사용" 
+            <Button Content="Use Selected" 
                     Command="{Binding UseSelectedCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="히스토리 지우기" 
+            <Button Content="Clear History" 
                     Command="{Binding ClearHistoryCommand}"
                     Style="{StaticResource ButtonStyle}"/>
-            <Button Content="닫기" 
+            <Button Content="Close" 
                     Click="CloseButton_Click"
                     Style="{StaticResource ButtonStyle}"/>
         </StackPanel>

--- a/UI/Views/HistoryWindow.xaml
+++ b/UI/Views/HistoryWindow.xaml
@@ -108,16 +108,20 @@
 
         <!-- Button Area -->
         <StackPanel Grid.Row="2" Orientation="Horizontal" 
-                    HorizontalAlignment="Right" Margin="0,10,0,0">
+            HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Use Selected" 
-                    Command="{Binding UseSelectedCommand}"
-                    Style="{StaticResource ButtonStyle}"/>
+            Command="{Binding UseSelectedCommand}"
+            Style="{StaticResource ButtonStyle}"/>
+            <Button Content="Delete Selected" 
+            Command="{Binding DeleteSelectedCommand}"
+            Style="{StaticResource ButtonStyle}"/>
             <Button Content="Clear History" 
-                    Command="{Binding ClearHistoryCommand}"
-                    Style="{StaticResource ButtonStyle}"/>
+            Command="{Binding ClearHistoryCommand}"
+            Style="{StaticResource ButtonStyle}"/>
             <Button Content="Close" 
-                    Click="CloseButton_Click"
-                    Style="{StaticResource ButtonStyle}"/>
+            Click="CloseButton_Click"
+            Style="{StaticResource ButtonStyle}"/>
         </StackPanel>
+
     </Grid>
 </Window>


### PR DESCRIPTION
- Fix history not being reflected when calculations are performed
- Remove duplicate constructors and consolidate history management
- Connect HistoryViewModel to use CalculatorViewModel's HistoryItems directly
- Remove unnecessary UpdateHistory() method and use HistoryService consistently
- Keep history window open when "Use Selected" is clicked for better workflow
- Enable continuous selection of multiple history items without closing window