### PR TITLE
feat(bitwise): Improve BitOperationsViewModel history parsing and NOT operation handling

### DIFF
--- a/UI/Views/BitOperationsWindow.xaml
+++ b/UI/Views/BitOperationsWindow.xaml
@@ -4,8 +4,8 @@
         xmlns:vm="clr-namespace:Calculator.UI.ViewModels"
 
         Title="Bit Operations Calculator"
-        Height="647"
-        Width="623"
+        Height="728"
+        Width="734"
         ResizeMode="CanResize"
         WindowStartupLocation="CenterScreen"
         MinHeight="500"
@@ -192,7 +192,7 @@
         </GroupBox>
 
         <!-- Operations Section -->
-        <GroupBox Grid.Row="3" Header="Operations" Padding="10" Margin="0,0,0,10">
+        <GroupBox Grid.Row="3" Header="Operations" Padding="10" Margin="0,67,0,10">
             <UniformGrid Rows="2" Columns="4">
                 <Button Content="AND (A &amp; B)" Command="{Binding AndCommand}" 
                         Style="{StaticResource OperationButtonStyle}" />


### PR DESCRIPTION
Refactor ParseAndSetOperands to reliably extract operands using regex

Ensure NOT operations from history always populate OperandA correctly

Reset OperandB to 0 for unary NOT operations to maintain consistent state

Fix issue where consecutive NOT history selections failed to update inputs correctly